### PR TITLE
Build changes and readme

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,6 +1,6 @@
 name: Lint and test
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build_and_test:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Claudia Zendejas-Morales and Piotr Migdał
+Copyright (c) 2021 Claudia Zendejas-Morales and Piotr Migdał - Qunatum Flytrap
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,127 +1,46 @@
-# Tensor diagrams D3.js
+# Tensor diagrams - Penrose graphical notation in D3.js
 
-By [Piotr Migdał](https://p.migdal.pl/) and [Claudia Zendejas-Morales](https://claudiazm.xyz/). Inspirations include http://tensornetwork.org/diagrams/.
+[![npm version](https://badge.fury.io/js/tensor-diagrams.svg)](https://badge.fury.io/js/tensor-diagrams)
+![License](https://img.shields.io/npm/l/tensor-diagrams)
+![Buld status](https://github.com/Quantum-Game/tensor-diagrams/actions/workflows/lint-and-test.yml/badge.svg)
+[![Twitter @QuantumGameIO](https://img.shields.io/twitter/follow/QuantumGameIO)](https://twitter.com/quantumgameio)
+
+A package for creating visual tensor diagrams using [Penrose graphical notation](https://en.wikipedia.org/wiki/Penrose_graphical_notation) in D3js. For machine learning, deep learning, quantum computing, quantum information, and other array operations.By [Piotr Migdał](https://p.migdal.pl/) and [Claudia Zendejas-Morales](https://claudiazm.xyz/) from [Quantum Flytrap](https://quantumflytrap.com/).  
+
+A simple live version: https://jsfiddle.net/stared/aeLtrvb7/.
+
+Inspirations include:
+
+* http://tensornetwork.org/diagrams/
+* [Matrices as Tensor Network Diagrams](https://www.math3ma.com/blog/matrices-as-tensor-network-diagrams) by Tai-Danae Bradley
+* [Drawing Trace Diagrams with TikZ](http://elishapeterson.wikidot.com/tikz:diagrams) by Elisha Peterson
+* Piotr's longstanding interest in data visualization of array operations
+  * [⟨𝜑|𝜓⟩.vue - a Vue-based visualization of quantum states and operations](https://github.com/Quantum-Game/bra-ket-vue)
+  * [Simple diagrams of convoluted neural networks](https://p.migdal.pl/2018/09/15/simple-diagrams-deep-learning.html)
+  * [Symmetries and self-similarity of many-body wavefunctions](https://arxiv.org/abs/1412.6796)
 
 
-## TypeScript Boilerplate for 2021
+## Local setup
 
-[![Build and test status](https://github.com/metachris/typescript-boilerplate/workflows/Lint%20and%20test/badge.svg)](https://github.com/metachris/micropython-ctl/actions?query=workflow%3A%22Build+and+test%22)
-
-TypeScript project boilerplate with modern tooling, for Node.js programs, libraries and browser modules. Get started quickly and right-footed 🚀
-
-* [TypeScript 4](https://www.typescriptlang.org/)
-* Optionally [esbuild](https://esbuild.github.io/) to bundle for browsers (and Node.js)
-* Linting with [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint) ([tslint](https://palantir.github.io/tslint/) is deprecated)
-* Testing with [Jest](https://jestjs.io/docs/getting-started) (and [ts-jest](https://www.npmjs.com/package/ts-jest))
-* Publishing to npm
-* Continuous integration ([GitHub Actions](https://docs.github.com/en/actions) / [GitLab CI](https://docs.gitlab.com/ee/ci/))
-* Automatic API documentation with [TypeDoc](https://typedoc.org/guides/doccomments/)
-
-See also the introduction blog post: **[Starting a TypeScript Project in 2021](https://www.metachris.com/2021/03/bootstrapping-a-typescript-node.js-project/)**.
-
-
-## Getting Started
+Created using a NPM TypeScript frontend boilerplate [metachris/typescript-boilerplate](https://github.com/metachris/typescript-boilerplate/), which uses [esbuild](https://esbuild.github.io/), and is described in detail in [Blog post: Starting a TypeScript Project in 2021](https://www.metachris.com/2021/03/bootstrapping-a-typescript-node.js-project/).
 
 ```bash
-# Clone the repository (you can also click "Use this template")
-git clone https://github.com/metachris/typescript-boilerplate.git your_project_name
-cd your_project_name
-
-# Edit `package.json` and `tsconfig.json` to your liking
-...
+# Clone the repository
+git clone https://github.com/Quantum-Game/tensor-diagrams
+cd https://github.com/Quantum-Game/tensor-diagrams
 
 # Install dependencies
 yarn install
 
 # Now you can run various yarn commands:
-yarn cli
 yarn lint
 yarn test
 yarn build-all
-yarn ts-node <filename>
 yarn esbuild-browser
-...
-```
-
-* Take a look at all the scripts in [`package.json`](https://github.com/metachris/typescript-boilerplate/blob/master/package.json)
-* For publishing to npm, use `yarn publish` (or `npm publish`)
-
-## esbuild
-
-[esbuild](https://esbuild.github.io/) is an extremely fast bundler that supports a [large part of the TypeScript syntax](https://esbuild.github.io/content-types/#typescript). This project uses it to bundle for browsers (and Node.js if you want).
-
-```bash
-# Build for browsers
-yarn esbuild-browser:dev
-yarn esbuild-browser:watch
-
-# Build the cli for node
-yarn esbuild-node:dev
-yarn esbuild-node:watch
-```
-
-You can generate a full clean build with `yarn build-all` (which uses both `tsc` and `esbuild`).
-
-* `package.json` includes `scripts` for various esbuild commands: [see here](https://github.com/metachris/typescript-boilerplate/blob/master/package.json#L23)
-* `esbuild` has a `--global-name=xyz` flag, to store the exports from the entry point in a global variable. See also the [esbuild "Global name" docs](https://esbuild.github.io/api/#global-name).
-* Read more about the esbuild setup [here](https://www.metachris.com/2021/04/starting-a-typescript-project-in-2021/#esbuild).
-* esbuild for the browser uses the IIFE (immediately-invoked function expression) format, which executes the bundled code on load (see also https://github.com/evanw/esbuild/issues/29)
-
-
-## Tests with Jest
-
-You can write [Jest tests](https://jestjs.io/docs/getting-started) [like this](https://github.com/metachris/typescript-boilerplate/blob/master/src/main.test.ts):
-
-```typescript
-import { greet } from './main'
-
-test('the data is peanut butter', () => {
-  expect(1).toBe(1)
-});
-
-test('greeting', () => {
-  expect(greet('Foo')).toBe('Hello Foo')
-});
-```
-
-Run the tests with `yarn test`, no separate compile step is necessary.
-
-* See also the [Jest documentation](https://jestjs.io/docs/getting-started).
-* The tests can be automatically run in CI (GitHub Actions, GitLab CI): [`.github/workflows/lint-and-test.yml`](https://github.com/metachris/typescript-boilerplate/blob/master/.github/workflows/lint-and-test.yml), [`.gitlab-ci.yml`](https://github.com/metachris/typescript-boilerplate/blob/master/.gitlab-ci.yml)
-* Take a look at other modern test runners such as [ava](https://github.com/avajs/ava), [uvu](https://github.com/lukeed/uvu) and [tape](https://github.com/substack/tape)
-
-## Documentation, published with CI
-
-You can auto-generate API documentation from the TyoeScript source files using [TypeDoc](https://typedoc.org/guides/doccomments/). The generated documentation can be published to GitHub / GitLab pages through the CI.
-
-Generate the documentation, using `src/main.ts` as entrypoint (configured in package.json):
-
-```bash
 yarn docs
 ```
-
-The resulting HTML is saved in `docs/`.
-
-You can publish the documentation through CI:
-* [GitHub pages](https://pages.github.com/): See [`.github/workflows/deploy-gh-pages.yml`](https://github.com/metachris/typescript-boilerplate/blob/master/.github/workflows/deploy-gh-pages.yml)
-* [GitLab pages](https://docs.gitlab.com/ee/user/project/pages/): [`.gitlab-ci.yml`](https://github.com/metachris/typescript-boilerplate/blob/master/.gitlab-ci.yml)
-
-This is the documentation for this boilerplate project: https://metachris.github.io/typescript-boilerplate/
-
-## References
-
-* **[Blog post: Starting a TypeScript Project in 2021](https://www.metachris.com/2021/03/bootstrapping-a-typescript-node.js-project/)**
-* [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/intro.html)
-* [tsconfig docs](https://www.typescriptlang.org/tsconfig)
-* [esbuild docs](https://esbuild.github.io/)
-* [typescript-eslint docs](https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/README.md)
-* [Jest docs](https://jestjs.io/docs/getting-started)
-* [GitHub Actions](https://docs.github.com/en/actions), [GitLab CI](https://docs.gitlab.com/ee/ci/)
 
 
 ## Feedback
 
-Reach out with feedback and ideas:
-
-* [twitter.com/metachris](https://twitter.com/metachris)
-* [Create a new issue](https://github.com/metachris/typescript-boilerplate/issues)
+The easiest feedback is by opening a [GitHub Issue](https://github.com/Quantum-Game/tensor-diagrams/issues).

--- a/browser-test.html
+++ b/browser-test.html
@@ -1,9 +1,8 @@
 <html>
 
 <head>
-  <script src="./dist/esbuild/browser.js"></script>
+  <script src="./dist/esbuild/tensor-diagrams.js"></script>
   <link rel='stylesheet' href='./src/diagram.css'>
-  <!-- <script src="https://cdn.jsdelivr.net/npm/typescript-boilerplate-2021"></script> -->
 </head>
 
 <body>

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "docs": "typedoc --entryPoints src/main.ts",
     "build": "tsc -p tsconfig.json",
     "build-all": "yarn clean && yarn build && yarn esbuild-browser",
-    "esbuild-browser": "esbuild src/browser.ts --bundle --minify --sourcemap=external --outfile=dist/esbuild/tensor-diagrams.js",
+    "esbuild-browser": "esbuild src/browser.ts --bundle --external:d3 --minify --sourcemap=external --outfile=dist/esbuild/tensor-diagrams.js",
     "esbuild-browser:dev": "esbuild src/browser.ts --bundle --outfile=dist/esbuild/tensor-diagrams.js",
     "esbuild-browser:watch": "esbuild src/browser.ts --bundle --watch --outfile=dist/esbuild/tensor-diagrams.js"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "docs": "typedoc --entryPoints src/main.ts",
     "build": "tsc -p tsconfig.json",
     "build-all": "yarn clean && yarn build && yarn esbuild-browser",
-    "esbuild-browser": "esbuild src/browser.ts --bundle --external:d3 --minify --sourcemap=external --outfile=dist/esbuild/tensor-diagrams.js",
+    "esbuild-browser": "esbuild src/browser.ts --bundle --minify --sourcemap=external --outfile=dist/esbuild/tensor-diagrams.js",
     "esbuild-browser:dev": "esbuild src/browser.ts --bundle --outfile=dist/esbuild/tensor-diagrams.js",
     "esbuild-browser:watch": "esbuild src/browser.ts --bundle --watch --outfile=dist/esbuild/tensor-diagrams.js"
   },

--- a/package.json
+++ b/package.json
@@ -15,24 +15,17 @@
   "main": "./dist/tsc/main.js",
   "types": "./dist/tsc/main.d.ts",
   "browser": "./dist/esbuild/browser.js",
-  "bin": {
-    "my-cli-tool": "./dist/esbuild/cli.js"
-  },
   "scripts": {
-    "cli": "ts-node src/cli.ts",
     "lint": "eslint src/ --ext .js,.jsx,.ts,.tsx",
     "test": "jest",
     "clean": "rm -rf dist build package",
     "ts-node": "ts-node",
     "docs": "typedoc --entryPoints src/main.ts",
     "build": "tsc -p tsconfig.json",
-    "build-all": "yarn clean && yarn build && yarn esbuild-node && yarn esbuild-browser",
+    "build-all": "yarn clean && yarn build && yarn esbuild-browser",
     "esbuild-browser": "esbuild src/browser.ts --bundle --minify --sourcemap=external --outfile=dist/esbuild/browser.js",
     "esbuild-browser:dev": "esbuild src/browser.ts --bundle --outfile=dist/esbuild/browser.js",
-    "esbuild-browser:watch": "esbuild src/browser.ts --bundle --watch --outfile=dist/esbuild/browser.js",
-    "esbuild-node": "esbuild src/cli.ts --bundle --platform=node --minify --sourcemap=external --outfile=dist/esbuild/cli.js",
-    "esbuild-node:dev": "esbuild src/cli.ts --bundle --sourcemap=external --outfile=dist/esbuild/cli.js",
-    "esbuild-node:watch": "esbuild src/cli.ts --bundle --watch --sourcemap=external --outfile=dist/esbuild/cli.js"
+    "esbuild-browser:watch": "esbuild src/browser.ts --bundle --watch --outfile=dist/esbuild/browser.js"
   },
   "devDependencies": {
     "@types/jest": "^26.0.21",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "main": "./dist/tsc/main.js",
   "types": "./dist/tsc/main.d.ts",
-  "browser": "./dist/esbuild/browser.js",
+  "browser": "./dist/esbuild/tensor-diagrams.js",
   "scripts": {
     "lint": "eslint src/ --ext .js,.jsx,.ts,.tsx",
     "test": "jest",
@@ -23,9 +23,9 @@
     "docs": "typedoc --entryPoints src/main.ts",
     "build": "tsc -p tsconfig.json",
     "build-all": "yarn clean && yarn build && yarn esbuild-browser",
-    "esbuild-browser": "esbuild src/browser.ts --bundle --minify --sourcemap=external --outfile=dist/esbuild/browser.js",
-    "esbuild-browser:dev": "esbuild src/browser.ts --bundle --outfile=dist/esbuild/browser.js",
-    "esbuild-browser:watch": "esbuild src/browser.ts --bundle --watch --outfile=dist/esbuild/browser.js"
+    "esbuild-browser": "esbuild src/browser.ts --bundle --minify --sourcemap=external --outfile=dist/esbuild/tensor-diagrams.js",
+    "esbuild-browser:dev": "esbuild src/browser.ts --bundle --outfile=dist/esbuild/tensor-diagrams.js",
+    "esbuild-browser:watch": "esbuild src/browser.ts --bundle --watch --outfile=dist/esbuild/tensor-diagrams.js"
   },
   "devDependencies": {
     "@types/jest": "^26.0.21",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,0 @@
-#!/usr/bin/env node
-import { foo } from './main'
-
-foo()


### PR DESCRIPTION
- [X] Browser build renamed from `browser.js` to `tensor-diagrams.js`
- [ ] Does not compile D3 in the browser build - it is D3@7 is a separate dependency 
- [X] Removed CLI builds
- [X] Wrote README for this project
- [X] Project badges
- [x] Change local browser test