### PR TITLE
Code refactor to make it D3-way

### DIFF
--- a/browser-test.html
+++ b/browser-test.html
@@ -46,6 +46,7 @@
       .addContraction(0, 1, "i")
       .addContraction(1, 2, "j")
       .setSize(220, 120)
+      .setColorScheme(['x'], ['red'], 'd3category10')
       .draw("#simpler");
 
     TensorDiagram.new()

--- a/src/diagrams.ts
+++ b/src/diagrams.ts
@@ -74,9 +74,7 @@ export class TensorDiagram {
 
   height = 300;
 
-  colorScale = d3.scaleOrdinal<string, string, never>()
-    .domain(['dot', 'conv'])
-    .range(['black', 'black', '#763E9B', '#00882B', '#C82505', '#0165C0']);
+  colorScale = d3.scaleOrdinal<string, string, never>();
 
   xScale = d3.scaleLinear()
     .domain([0, 8])
@@ -100,6 +98,8 @@ export class TensorDiagram {
     }));
 
     this.lines = lines;
+
+    this.setColorScheme(['dot', 'conv'], ['black', 'black'], 'tensornetwork');
   }
 
   /**
@@ -213,7 +213,7 @@ export class TensorDiagram {
    * Set color scheme for tensors without explicitly defined colors.
    * @param names Tensor names to set color for.
    * @param color Color to set for the tensors followed by the next colors for other tensors.
-   * @params appendScheme Appends colors from a pre-defined color scheme.
+   * @param appendScheme Appends colors from a pre-defined color scheme.
    * @returns An updated TensorDiagram, so it is chainable.
   */
   setColorScheme(

--- a/src/diagrams.ts
+++ b/src/diagrams.ts
@@ -75,6 +75,14 @@ export class TensorDiagram {
 
   startColorIndex = 0; // this is interlan and should be removed
 
+  xScale = d3.scaleLinear()
+    .domain([0, 8])
+    .range([20, 500]);
+
+  yScale = d3.scaleLinear()
+    .domain([0, 8])
+    .range([60, 500]);
+
   constructor(tensors: Tensor[], contractions: Contraction[], lines: Line[]) {
     this.tensors = tensors;
 
@@ -259,14 +267,8 @@ export class TensorDiagram {
     const colorScale = d3.scaleOrdinal<string, string, never>()
       .range(['#763E9B', '#00882B', '#C82505', '#0165C0', '#EEEEEE'].slice(this.startColorIndex));
 
-    const xScale = d3.scaleLinear()
-      .domain([0, 8])
-      .range([20, 500]);
-
-    const yScale = d3.scaleLinear()
-      .domain([0, 8])
-      .range([60, 500]);
-
+    const { xScale } = this;
+    const { yScale } = this;
     const lineFunction = d3.line<XY>()
       .x((d) => xScale(d.x))
       .y((d) => yScale(d.y));
@@ -423,12 +425,12 @@ export class TensorDiagram {
       })
       .text((tensor) => tensor.name);
 
-    const { drawShape } = this;
+    const drawShape = this.drawShape.bind(this);
     // tensors
     tensorG
       // eslint-disable-next-line func-names
       .each(function (tensor) {
-        const shape = drawShape(this, tensor, xScale, yScale);
+        const shape = drawShape(this, tensor);
         shape.attr('class', 'tensor')
           .style('fill', (c) => {
             if (c.shape === 'dot') return 'black';
@@ -455,14 +457,12 @@ export class TensorDiagram {
   * @param yScale - callback that scales linearly on the y-axis.
   * @returns returns the generated shape so that it can be manipulated such as setting its fill color.
   */
-  // eslint-disable-next-line class-methods-use-this
   drawShape(
     element: SVGGElement,
     tensor: Tensor,
-    xScale: d3.ScaleLinear<number, number, never>,
-    yScale: d3.ScaleLinear<number, number, never>,
   ): d3.Selection<any, Tensor, null, undefined> {
     const selected = d3.select<SVGGElement, Tensor>(element);
+    const { xScale, yScale } = this;
     // the figure goes inside a box with an area equal to size*size
     // (in the case of the rectangle, its width is this size, but not its length)
     const { size } = tensor;

--- a/src/diagrams.ts
+++ b/src/diagrams.ts
@@ -167,16 +167,6 @@ export class TensorDiagram {
     const inds3 = up.map((s): Indice => ({ name: s, pos: 'up', showLabel: true }));
     const inds4 = down.map((s): Indice => ({ name: s, pos: 'down', showLabel: true }));
     const tensor = TensorDiagram.createTensor(pos.x, pos.y, name, inds1.concat(inds2).concat(inds3).concat(inds4));
-    // : Tensor = {
-    //   x: pos.x,
-    //   y: pos.y,
-    //   name,
-    //   shape: 'circle',
-    //   showLabel: true,
-    //   labPos: 'up',
-    //   size: 20,
-    //   indices: inds1.concat(inds2).concat(inds3).concat(inds4),
-    // };
     this.tensors.push(tensor);
     return this;
   }
@@ -208,6 +198,10 @@ export class TensorDiagram {
     return this;
   }
 
+  /**
+   * (Internal function)
+   * @returns Lose indice lines.
+   */
   indicesToDraw(): IndiceDrawable[][] {
     const shifts = {
       up: [0.00, -0.75],
@@ -410,17 +404,22 @@ export class TensorDiagram {
     tensorG.append('text')
       .attr('class', 'tensor-label')
       .attr('x', (tensor) => {
-        let shiftHor = 0;
-        if (tensor.labPos.startsWith('left')) shiftHor = -0.4;
-        if (tensor.labPos.startsWith('right')) shiftHor = 0.4;
-        return xScale(tensor.x + shiftHor);
+        const shiftX = {
+          left: -0.4,
+          right: 0.4,
+          up: 0,
+          down: 0,
+        };
+        return xScale(tensor.x + shiftX[tensor.labPos]);
       })
       .attr('y', (tensor) => {
-        let shiftVer = 0;
-        if (tensor.labPos.endsWith('up')) shiftVer = -0.4;
-        if (tensor.labPos.endsWith('down')) shiftVer = 0.6;
-        if (tensor.labPos === 'left' || tensor.labPos === 'right') shiftVer += 0.14;
-        return yScale(tensor.y + shiftVer);
+        const shiftY = {
+          left: 0.14,
+          right: 0.14,
+          up: -0.4,
+          down: 0.6,
+        };
+        return yScale(tensor.y + shiftY[tensor.labPos]);
       })
       .text((tensor) => tensor.name);
 

--- a/src/diagrams.ts
+++ b/src/diagrams.ts
@@ -150,6 +150,7 @@ export class TensorDiagram {
    * @param right Indice names for right.
    * @param up Indice names for up.
    * @param down Indice names for down.
+   * @param shape Visual shape of the tensor.
    * @returns An updated TensorDiagram, so it is chainable.
    */
   addTensor(
@@ -159,6 +160,7 @@ export class TensorDiagram {
     right: string[] = [],
     up: string[] = [],
     down: string[] = [],
+    shape: Shape = 'circle',
   ): TensorDiagram {
     let pos: XY = { x: 0, y: 0 };
     switch (position) {
@@ -177,7 +179,8 @@ export class TensorDiagram {
     const inds2 = right.map((s): Indice => ({ name: s, pos: 'right', showLabel: true }));
     const inds3 = up.map((s): Indice => ({ name: s, pos: 'up', showLabel: true }));
     const inds4 = down.map((s): Indice => ({ name: s, pos: 'down', showLabel: true }));
-    const tensor = TensorDiagram.createTensor(pos.x, pos.y, name, inds1.concat(inds2).concat(inds3).concat(inds4));
+    const indices = [...inds1, ...inds2, ...inds3, ...inds4];
+    const tensor = TensorDiagram.createTensor(pos.x, pos.y, name, indices, shape);
     this.tensors.push(tensor);
     return this;
   }

--- a/src/diagrams.ts
+++ b/src/diagrams.ts
@@ -424,11 +424,12 @@ export class TensorDiagram {
       })
       .text((tensor) => tensor.name);
 
+    const { drawShape } = this;
     // tensors
-    tensorG.each(function (tensor) {
-      const selected = d3.select<SVGGElement, Tensor>(this);
-      const shape = drawShape(selected, tensor, xScale, yScale);
-      if (shape) {
+    tensorG
+      // eslint-disable-next-line func-names
+      .each(function (tensor) {
+        const shape = drawShape(this, tensor, xScale, yScale);
         shape.attr('class', 'tensor')
           .style('fill', (c) => {
             if (c.shape === 'dot') return 'black';
@@ -441,180 +442,181 @@ export class TensorDiagram {
           .on('mouseout', (_event, c) => {
             div.selectAll(`.tensor-eq-${c.name}`).classed('circle-sketch-highlight', false);
           });
-      }
-    });
+      });
   }
-}
-
-/**
-* Determines the shape of the node (or tensor), appends it to the selected element (element of the svg figure),
-* this figure will be of the size specified for the particular tensor, remaining within the square box
-* of size d.size*d.size .
-* @param selected - represents the element within the svg figure to which the shape generated in this
-*     function will be added.
-* @param d - tensor object, contains all the characteristics of the tensor to be drawn.
-* @param xScale - callback that scales linearly on the x-axis.
-* @param yScale - callback that scales linearly on the y-axis.
-* @returns returns the generated shape so that it can be manipulated such as setting its fill color.
-*/
-function drawShape(
-  selected: d3.Selection<SVGGElement, Tensor, null, undefined>,
-  tensor: Tensor,
-  xScale: d3.ScaleLinear<number, number, never>,
-  yScale: d3.ScaleLinear<number, number, never>,
-): d3.Selection<any, Tensor, null, undefined> {
-  // the figure goes inside a box with an area equal to size*size
-  // (in the case of the rectangle, its width is this size, but not its length)
-  const { size } = tensor;
-  // radius of the circumscribed circle in the box where the figure goes, also the center of the figures is in size/2
-  const radius = size / 2;
-  // projection of the radius on the diagonal with angle pi/4
-  const diagonalRadius = Math.floor(Math.cos(Math.PI / 4) * radius);
-
-  // decide what to draw according to what is specified
-  const strToShapeFunction = {
-    circle: drawCircle,
-    dot: drawCircle,
-    asterisk: drawAsterisk,
-    square: drawSquare,
-    triangleUp: drawTriangleUp,
-    triangleDown: drawTriangleDown,
-    triangleLeft: drawTriangleLeft,
-    triangleRight: drawTriangleRight,
-    rectangle: drawRectangle,
-  };
-
-  // internal functions that draw specific shapes
 
   /**
+  * Determines the shape of the node (or tensor), appends it to the selected element (element of the svg figure),
+  * this figure will be of the size specified for the particular tensor, remaining within the square box
+  * of size d.size*d.size .
+  * @param selected - represents the element within the svg figure to which the shape generated in this
+  *     function will be added.
+  * @param d - tensor object, contains all the characteristics of the tensor to be drawn.
+  * @param xScale - callback that scales linearly on the x-axis.
+  * @param yScale - callback that scales linearly on the y-axis.
+  * @returns returns the generated shape so that it can be manipulated such as setting its fill color.
+  */
+  // eslint-disable-next-line class-methods-use-this
+  drawShape(
+    element: SVGGElement,
+    tensor: Tensor,
+    xScale: d3.ScaleLinear<number, number, never>,
+    yScale: d3.ScaleLinear<number, number, never>,
+  ): d3.Selection<any, Tensor, null, undefined> {
+    const selected = d3.select<SVGGElement, Tensor>(element);
+    // the figure goes inside a box with an area equal to size*size
+    // (in the case of the rectangle, its width is this size, but not its length)
+    const { size } = tensor;
+    // radius of the circumscribed circle in the box where the figure goes, also the center of the figures is in size/2
+    const radius = size / 2;
+    // projection of the radius on the diagonal with angle pi/4
+    const diagonalRadius = Math.floor(Math.cos(Math.PI / 4) * radius);
+
+    // decide what to draw according to what is specified
+    const strToShapeFunction = {
+      circle: drawCircle,
+      dot: drawCircle,
+      asterisk: drawAsterisk,
+      square: drawSquare,
+      triangleUp: drawTriangleUp,
+      triangleDown: drawTriangleDown,
+      triangleLeft: drawTriangleLeft,
+      triangleRight: drawTriangleRight,
+      rectangle: drawRectangle,
+    };
+
+    // internal functions that draw specific shapes
+
+    /**
    * Generates a circle shape.
    * @returns returns the generated circle shape.
    */
-  function drawCircle() {
-    return selected
-      .append('circle')
-      .attr('r', tensor.shape === 'dot' ? radius / 2 : radius)
-      .attr('cx', (d) => xScale(d.x))
-      .attr('cy', (d) => yScale(d.y));
-  }
+    function drawCircle() {
+      return selected
+        .append('circle')
+        .attr('r', tensor.shape === 'dot' ? radius / 2 : radius)
+        .attr('cx', (d) => xScale(d.x))
+        .attr('cy', (d) => yScale(d.y));
+    }
 
-  /**
+    /**
    * Generates an asterisk shape.
    * @returns returns the generated asterisk shape.
    */
-  function drawAsterisk() {
-    return selected
-      .append('path')
-      .attr('d', (d) => {
-        const sx = xScale(d.x);
-        const sy = yScale(d.y);
-        return ` M ${sx - diagonalRadius} ${sy - diagonalRadius
-        } L ${sx + diagonalRadius} ${sy + diagonalRadius
-        } M ${sx + diagonalRadius} ${sy - diagonalRadius
-        } L ${sx - diagonalRadius} ${sy + diagonalRadius
-        } M ${sx} ${sy - radius
-        } L ${sx} ${sy + radius
-        } M ${sx + radius} ${sy
-        } L ${sx - radius} ${sy}`;
-      });
-  }
+    function drawAsterisk() {
+      return selected
+        .append('path')
+        .attr('d', (d) => {
+          const sx = xScale(d.x);
+          const sy = yScale(d.y);
+          return ` M ${sx - diagonalRadius} ${sy - diagonalRadius
+          } L ${sx + diagonalRadius} ${sy + diagonalRadius
+          } M ${sx + diagonalRadius} ${sy - diagonalRadius
+          } L ${sx - diagonalRadius} ${sy + diagonalRadius
+          } M ${sx} ${sy - radius
+          } L ${sx} ${sy + radius
+          } M ${sx + radius} ${sy
+          } L ${sx - radius} ${sy}`;
+        });
+    }
 
-  /**
+    /**
    * Generates a square shape.
    * @returns returns the generated square shape.
    */
-  function drawSquare() {
-    return selected
-      .append('rect')
-      .attr('width', size)
-      .attr('height', size)
-      .attr('x', (d) => xScale(d.x) - radius)
-      .attr('y', (d) => yScale(d.y) - radius);
-  }
+    function drawSquare() {
+      return selected
+        .append('rect')
+        .attr('width', size)
+        .attr('height', size)
+        .attr('x', (d) => xScale(d.x) - radius)
+        .attr('y', (d) => yScale(d.y) - radius);
+    }
 
-  /**
+    /**
    * Generates a triangle up-pointing shape.
    * @returns returns the generated triangle up-pointing shape.
    */
-  function drawTriangleUp() {
-    return selected
-      .append('path')
-      .attr('d', (d) => {
-        const sx = xScale(d.x) - radius;
-        const sy = yScale(d.y) + radius;
-        return ` M ${sx} ${sy
-        } L ${sx + size} ${sy
-        } L ${sx + radius} ${sy - size
-        } z `;
-      });
-  }
+    function drawTriangleUp() {
+      return selected
+        .append('path')
+        .attr('d', (d) => {
+          const sx = xScale(d.x) - radius;
+          const sy = yScale(d.y) + radius;
+          return ` M ${sx} ${sy
+          } L ${sx + size} ${sy
+          } L ${sx + radius} ${sy - size
+          } z `;
+        });
+    }
 
-  /**
+    /**
    * Generates a triangle down-pointing shape.
    * @returns returns the generated triangle down-pointing shape.
    */
-  function drawTriangleDown() {
-    return selected
-      .append('path')
-      .attr('d', (d) => {
-        const sx = xScale(d.x) - radius;
-        const sy = yScale(d.y) - radius;
-        return ` M ${sx} ${sy
-        } L ${sx + size} ${sy
-        } L ${sx + radius} ${sy + size
-        } z `;
-      });
-  }
+    function drawTriangleDown() {
+      return selected
+        .append('path')
+        .attr('d', (d) => {
+          const sx = xScale(d.x) - radius;
+          const sy = yScale(d.y) - radius;
+          return ` M ${sx} ${sy
+          } L ${sx + size} ${sy
+          } L ${sx + radius} ${sy + size
+          } z `;
+        });
+    }
 
-  /**
+    /**
    * Generates a triangle left-pointing shape.
    * @returns returns the generated triangle left-pointing shape.
    */
-  function drawTriangleLeft() {
-    return selected
-      .append('path')
-      .attr('d', (d) => {
-        const sx = xScale(d.x) - radius;
-        const sy = yScale(d.y);
-        return ` M ${sx} ${sy
-        } L ${sx + size} ${sy + radius
-        } L ${sx + size} ${sy - radius
-        } z `;
-      });
-  }
+    function drawTriangleLeft() {
+      return selected
+        .append('path')
+        .attr('d', (d) => {
+          const sx = xScale(d.x) - radius;
+          const sy = yScale(d.y);
+          return ` M ${sx} ${sy
+          } L ${sx + size} ${sy + radius
+          } L ${sx + size} ${sy - radius
+          } z `;
+        });
+    }
 
-  /**
+    /**
    * Generates a triangle right-pointing shape.
    * @returns returns the generated triangle right-pointing shape.
    */
-  function drawTriangleRight() {
-    return selected
-      .append('path')
-      .attr('d', (d) => {
-        const sx = xScale(d.x) - radius;
-        const sy = yScale(d.y) - radius;
-        return ` M ${sx} ${sy
-        } L ${sx} ${sy + size
-        } L ${sx + size} ${sy + radius} z`;
-      });
-  }
+    function drawTriangleRight() {
+      return selected
+        .append('path')
+        .attr('d', (d) => {
+          const sx = xScale(d.x) - radius;
+          const sy = yScale(d.y) - radius;
+          return ` M ${sx} ${sy
+          } L ${sx} ${sy + size
+          } L ${sx + size} ${sy + radius} z`;
+        });
+    }
 
-  /**
+    /**
    * Generates a rectangle shape.
    * @returns returns the generated rectangle shape.
    */
-  function drawRectangle() {
+    function drawRectangle() {
     // the height of the rectangle will depend on the number of indices it has, either on the left or on the right
-    return selected
-      .append('rect')
-      .attr('width', size)
-      .attr('height', (d) => yScale(d.rectHeight - 2) + (radius * 1.5))
-      .attr('x', (d) => xScale(d.x) - radius)
-      .attr('y', (d) => yScale(d.y) - radius)
-      .attr('rx', diagonalRadius)
-      .attr('ry', diagonalRadius);
-  }
+      return selected
+        .append('rect')
+        .attr('width', size)
+        .attr('height', (d) => yScale(d.rectHeight - 2) + (radius * 1.5))
+        .attr('x', (d) => xScale(d.x) - radius)
+        .attr('y', (d) => yScale(d.y) - radius)
+        .attr('rx', diagonalRadius)
+        .attr('ry', diagonalRadius);
+    }
 
-  // return the shape to be added to the node
-  return strToShapeFunction[tensor.shape]();
+    // return the shape to be added to the node
+    return strToShapeFunction[tensor.shape]();
+  }
 }

--- a/src/diagrams.ts
+++ b/src/diagrams.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as d3 from 'd3';
 
@@ -210,7 +211,7 @@ export class TensorDiagram {
    * (Internal function)
    * @returns Lose indice lines.
    */
-  indicesToDraw(): IndiceDrawable[][] {
+  loseIndices(): IndiceDrawable[][] {
     const shifts = {
       up: [0.00, -0.75],
       down: [0.00, 0.75],
@@ -259,16 +260,14 @@ export class TensorDiagram {
   }
 
   draw(container: string, createDiagramDiv = true, equationLabels: { name: string, label: string }[] = []): void {
-    const { tensors } = this;
-    const { contractions } = this;
-    const { lines } = this;
+    const {
+      tensors, contractions, lines, xScale, yScale,
+    } = this;
 
     // define a color scale to assign colors to nodes
     const colorScale = d3.scaleOrdinal<string, string, never>()
       .range(['#763E9B', '#00882B', '#C82505', '#0165C0', '#EEEEEE'].slice(this.startColorIndex));
 
-    const { xScale } = this;
-    const { yScale } = this;
     const lineFunction = d3.line<XY>()
       .x((d) => xScale(d.x))
       .y((d) => yScale(d.y));
@@ -381,9 +380,9 @@ export class TensorDiagram {
       .attr('class', 'tensor-group');
 
     // lose indice lines
-    const indicesToDraw = this.indicesToDraw();
+    const loseIndices = this.loseIndices();
     tensorG.selectAll('.contraction')
-      .data((_tensor, i) => indicesToDraw[i])
+      .data((_tensor, i) => loseIndices[i])
       .enter()
       .append('path')
       .attr('class', 'contraction')
@@ -391,7 +390,7 @@ export class TensorDiagram {
 
     // lose indice labels
     tensorG.selectAll('.contraction-label')
-      .data((_tensor, i) => indicesToDraw[i])
+      .data((_tensor, i) => loseIndices[i])
       .enter()
       .append('text')
       .attr('class', 'contraction-label')


### PR DESCRIPTION
- [X] more functional (removing not needed `let` and `each`)
- [X] data from vis separated better (no data modification in `d3.selection`)
- [X] more hierarchical DOM structure - groups for tensors
- [ ] groups for lines?
- [ ] class naming (e.g. use `contraction` only for contractions)
- [x] explore `call` instead of `each`/`select(this)` pattern -> stayed with `each`
- [X] make drawShape a method
- [X] linear scales as class properties
- [x] make color scales consistent 

![image](https://user-images.githubusercontent.com/1001610/123944780-bda91600-d99d-11eb-8c79-b1f7d1f77c98.png)
