### PR TITLE
Ability to indicate two positions form tensor label

### DIFF
--- a/browser-test.html
+++ b/browser-test.html
@@ -17,6 +17,7 @@
   <div id="simpler" class="equation"></div>
   <div id="simpler-formula" class="equation"></div>
   <div id="trAB" class="equation"></div>
+  <div id="tensorLabel" class="equation"></div>
   <script>
     const tensors = [
       TensorDiagram.createTensor(0, 0, "x", [
@@ -72,6 +73,10 @@
       .setSize(220, 120)
       .draw("#trAB");
 
+    TensorDiagram.new()
+      .addTensor("A", { x: 1, y: 0 }, [], [], [], [], { labelPos: 'up left' })
+      .setSize(140, 120)
+      .draw("#tensorLabel");
 
   </script>
 </body>

--- a/src/diagrams.ts
+++ b/src/diagrams.ts
@@ -7,6 +7,7 @@ interface XY {
   y: number
 }
 
+// TODO: use a different type depending if 4 or 9 positions
 type Pos = 'left' | 'right' | 'up' | 'down' | 'center' | 'up left' | 'up right' | 'down left' | 'down right';
 
 type Shape = 'circle' | 'dot' | 'asterisk' | 'square' | 'triangleUp'

--- a/src/diagrams.ts
+++ b/src/diagrams.ts
@@ -492,7 +492,7 @@ export class TensorDiagram {
           up: 0,
           down: 0,
         };
-        return xScale(tensor.x + shiftX[tensor.labPos]);
+        return xScale(tensor.x + shiftX[tensor.labPos.split(" ", 2)[1] ?? tensor.labPos]);
       })
       .attr('y', (tensor) => {
         const shiftY = {
@@ -501,7 +501,7 @@ export class TensorDiagram {
           up: -0.4,
           down: 0.6,
         };
-        return yScale(tensor.y + shiftY[tensor.labPos]);
+        return yScale(tensor.y + shiftY[tensor.labPos.split(" ", 1)[0]]);
       })
       .text((tensor) => (tensor.showLabel ? tensor.name : ''));
 

--- a/src/diagrams.ts
+++ b/src/diagrams.ts
@@ -492,7 +492,7 @@ export class TensorDiagram {
           up: 0,
           down: 0,
         };
-        return xScale(tensor.x + shiftX[tensor.labPos.split(" ", 2)[1] ?? tensor.labPos]);
+        return xScale(tensor.x + shiftX[tensor.labPos.split(' ', 2)[1] ?? tensor.labPos]);
       })
       .attr('y', (tensor) => {
         const shiftY = {
@@ -501,7 +501,7 @@ export class TensorDiagram {
           up: -0.4,
           down: 0.6,
         };
-        return yScale(tensor.y + shiftY[tensor.labPos.split(" ", 1)[0]]);
+        return yScale(tensor.y + shiftY[tensor.labPos.split(' ', 1)[0]]);
       })
       .text((tensor) => (tensor.showLabel ? tensor.name : ''));
 

--- a/src/diagrams.ts
+++ b/src/diagrams.ts
@@ -7,7 +7,7 @@ interface XY {
   y: number
 }
 
-type Pos = 'left' | 'right' | 'up' | 'down';
+type Pos = 'left' | 'right' | 'up' | 'down' | 'center' | 'up left' | 'up right' | 'down left' | 'down right';
 
 type Shape = 'circle' | 'dot' | 'asterisk' | 'square' | 'triangleUp'
 | 'triangleDown' | 'triangleLeft' | 'triangleRight' | 'rectangle';
@@ -491,8 +491,13 @@ export class TensorDiagram {
           right: 0.4,
           up: 0,
           down: 0,
+          center: 0,
+          'up left': -0.4,
+          'down left': -0.4,
+          'up right': 0.4,
+          'down right': 0.4,
         };
-        return xScale(tensor.x + shiftX[tensor.labPos.split(' ', 2)[1] ?? tensor.labPos]);
+        return xScale(tensor.x + shiftX[tensor.labPos]);
       })
       .attr('y', (tensor) => {
         const shiftY = {
@@ -500,8 +505,13 @@ export class TensorDiagram {
           right: 0.14,
           up: -0.4,
           down: 0.6,
+          center: 0,
+          'up left': -0.4,
+          'down left': 0.6,
+          'up right': -0.4,
+          'down right': 0.6,
         };
-        return yScale(tensor.y + shiftY[tensor.labPos.split(' ', 1)[0]]);
+        return yScale(tensor.y + shiftY[tensor.labPos]);
       })
       .text((tensor) => (tensor.showLabel ? tensor.name : ''));
 


### PR DESCRIPTION
Add the ability to indicate two positions (first the vertical and then the horizontal) to draw the label of the tensor in 8 cardinal points.

Example:
`.addTensor ("A", {x: 1, y: 0}, [], [], [], [], {labelPos: 'up left'})`
It will draw the label of the tensor in the northwest.

Note: it does not work if it is indicated in reverse: `{labelPos: 'left up'}`

![image](https://user-images.githubusercontent.com/1554515/125184598-b925fe00-e1e4-11eb-9c08-2ab1349c0503.png)

